### PR TITLE
Fix set conf issue

### DIFF
--- a/src/main/scala/io/xskipper/configuration/Conf.scala
+++ b/src/main/scala/io/xskipper/configuration/Conf.scala
@@ -146,7 +146,10 @@ abstract class Configuration {
     * @param params a map of parameters to be set
     */
   def setConf(params: Map[String, String]): Unit = {
-    confEntries.putAll(params.asJava)
+    params.foreach {
+      case (key: String, value: String) => set(key, value)
+      case _ =>
+    }
   }
 
   // overload - getting a java map (for python module)

--- a/src/main/scala/io/xskipper/configuration/XskipperConf.scala
+++ b/src/main/scala/io/xskipper/configuration/XskipperConf.scala
@@ -16,17 +16,15 @@ import org.apache.spark.internal.Logging
 object XskipperConf extends Configuration with Logging {
   // override to enable custom action after setting for example:
   // the set function to reload identifier class
-  override def setConf(params: Map[String, String]): Unit = {
-    super.setConf(params)
+  override def set(key: String, value: String): Unit = {
+    super.set(key, value)
     // reload identifier class if needed
-    params.get(XSKIPPER_IDENTIFIER_CLASS_KEY) match {
-      case Some(identifierClass) =>
-        // try loading the class dynamically
-        Utils.getClassInstance[Identifier](identifierClass) match {
-          case Some(identifier) => Utils.identifier = identifier
-          case _ =>
-        }
-      case _ =>
+    if (key == XSKIPPER_IDENTIFIER_CLASS_KEY) {
+      // try loading the class dynamically
+      Utils.getClassInstance[Identifier](value) match {
+        case Some(identifier) => Utils.identifier = identifier
+        case _ =>
+      }
     }
   }
 

--- a/src/test/scala/io/xskipper/configuration/XskipperConfSuite.scala
+++ b/src/test/scala/io/xskipper/configuration/XskipperConfSuite.scala
@@ -6,6 +6,8 @@
 package io.xskipper.configuration
 
 import io.xskipper.Xskipper
+import io.xskipper.utils.Utils
+import io.xskipper.utils.identifier.IBMCOSIdentifier
 import org.scalatest.FunSuite
 
 import scala.collection.mutable
@@ -82,5 +84,17 @@ class XskipperConfSuite extends FunSuite {
     assertDefault(XskipperConf.XSKIPPER_TIMEOUT)
     assertDefault(XskipperConf.XSKIPPER_INDEX_DRIVER_MEMORY_FRACTION)
     assertDefault(XskipperConf.XSKIPPER_MINMAX_IN_FILTER_THRESHOLD)
+  }
+
+  test("setting custom identifier class using set") {
+    Xskipper.set("io.xskipper.identifierclass",
+      "io.xskipper.utils.identifier.IBMCOSIdentifier")
+    assert(Utils.identifier.isInstanceOf[IBMCOSIdentifier])
+  }
+
+  test("setting custom identifier class using set conf") {
+    Xskipper.setConf(Map("io.xskipper.identifierclass"->
+      "io.xskipper.utils.identifier.IBMCOSIdentifier"))
+    assert(Utils.identifier.isInstanceOf[IBMCOSIdentifier])
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

When using `set` to set the identifier class it wasn't set because the code path that load the identifier class was used only when using `setConf` which sets a map of parameters.

This PR merges the code path for `set` and `setConf` to avoid duplication and makes sure the identifier class is set in both.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Adding tests.