### PR TITLE
Spark 3.1.2 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           architecture: x64
       - name: Install Python packages (Python 3.7)
         run: |
-          python3.7 -m pip install pyspark==3.0.1
+          python3.7 -m pip install pyspark==3.1.2
       - name: Run sbt clean
         run: build/sbt ++2.12.8 clean
       - name: Run sbt compile

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -40,7 +40,7 @@ jobs:
           architecture: x64
       - name: Install Python packages (Python 3.7)
         run: |
-          python3.7 -m pip install pyspark==3.0.1
+          python3.7 -m pip install pyspark==3.1.2
       - name: Run sbt clean
         run: build/sbt ++2.12.8 clean
       - name: Run sbt compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           architecture: x64
       - name: Install Python packages (Python 3.7)
         run: |
-          python3.7 -m pip install pyspark==3.0.1
+          python3.7 -m pip install pyspark==3.1.2
       - name: Run Python tests
         run: python3.7 run-tests.py
       - if: |

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ crossScalaVersions := Seq("2.12.8")
 
 scalaVersion := crossScalaVersions.value.head
 
-sparkVersion := "3.0.1"
+sparkVersion := "3.1.2"
 
 libraryDependencies ++= Seq (
   "org.apache.spark" %% "spark-hive" % sparkVersion.value % "provided",

--- a/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
+++ b/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
@@ -12,7 +12,8 @@ import io.xskipper.utils.Utils
 import io.xskipper.{Xskipper, XskipperException}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, FileTable}
+import org.apache.spark.sql.catalog.Table
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation, FileTable}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.{DataFrame, DataFrameReader, SparkSession}
@@ -323,8 +324,10 @@ class IndexBuilder(spark: SparkSession, uri: String, xskipper: Xskipper)
     val (format, rawOptions, fileIndex) = df.queryExecution.optimizedPlan.collect {
       case l@LogicalRelation(hfs: HadoopFsRelation, _, _, _) =>
         (hfs.fileFormat.toString, hfs.options, hfs.location)
-      case _@DataSourceV2ScanRelation(table: FileTable, _, _) =>
+      // scalastyle:off line.size.limit
+      case _@DataSourceV2ScanRelation(_@DataSourceV2Relation(table: FileTable, _, _, _, _), _, _) =>
         (table.formatName, table.properties().asScala.toMap, table.fileIndex)
+      // scalastyle:on line.size.limit
     }(0)
 
     // filter out "path" or "paths" entries from the options.

--- a/src/main/scala/io/xskipper/index/execution/MetadataProcessor.scala
+++ b/src/main/scala/io/xskipper/index/execution/MetadataProcessor.scala
@@ -15,7 +15,7 @@ import io.xskipper.utils.Utils
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, FileTable}
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation, FileTable}
 import org.apache.spark.sql.execution.datasources.{FileIndex, HadoopFsRelation, LogicalRelation, PartitionDirectory}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -45,10 +45,12 @@ object MetadataProcessor {
     df.queryExecution.optimizedPlan.collect {
       case l@LogicalRelation(hfs: HadoopFsRelation, _, _, _) =>
         hfs.location.listFiles(Seq.empty, Seq.empty)
-      case DataSourceV2ScanRelation(table: FileTable, _, _) =>
+      // scalastyle:off line.size.limit
+      case _@DataSourceV2ScanRelation(_@DataSourceV2Relation(table: FileTable, _, _, _, _), _, _) =>
         // not using allFiles since it returns also empty files which are not used
         // since Spark only calls list files during query processing
         table.fileIndex.listFiles(Seq.empty, Seq.empty)
+      // scalastyle:on line.size.limit
     }.flatten
   }
 }

--- a/src/main/scala/io/xskipper/utils/Utils.scala
+++ b/src/main/scala/io/xskipper/utils/Utils.scala
@@ -17,7 +17,6 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.catalyst.expressions.{Expression, GetStructField, _}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.{SQLDate, SQLTimestamp}
 import org.apache.spark.sql.catalyst.{InternalRow, util => CatalystUtils}
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, FileScan}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
@@ -310,10 +309,10 @@ object Utils extends Logging {
     while (i < len) {
       fieldTypes(i) match {
         case dt: DateType =>
-          values(i) = DateTimeUtils.toJavaDate(row.get(i, dt).asInstanceOf[SQLDate])
+          values(i) = DateTimeUtils.toJavaDate(row.get(i, dt).asInstanceOf[Int])
         case dt: StringType => values(i) = row.get(i, dt).toString
         case dt: TimestampType =>
-          values(i) = DateTimeUtils.toJavaTimestamp(row.get(i, dt).asInstanceOf[SQLTimestamp])
+          values(i) = DateTimeUtils.toJavaTimestamp(row.get(i, dt).asInstanceOf[Long])
         case _ => values(i) = row.get(i, fieldTypes(i))
       }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/xskipper/DataSkippingUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/xskipper/DataSkippingUtils.scala
@@ -26,7 +26,7 @@ object DataSkippingUtils extends Logging {
 
   /**
     * This function contains the same logic for creating the FileIndex as appears in
-    * PartitioningAwareFileIndex class and replaces the InMemoryFileIndex with
+    * FileTable class and replaces the InMemoryFileIndex with
     * InMemoryDataSkippingIndex.
     * The reason for keeping the same logic is that the original variable is lazy
     * so we can rely on not having the FileIndex created until this function is called.
@@ -45,8 +45,10 @@ object DataSkippingUtils extends Logging {
         options.asScala.toMap, userSpecifiedSchema)
     } else {
       // This is a non-streaming file based datasource.
+      val globPaths = Option(options.get(DataSource.GLOB_PATHS_KEY))
+        .map(_ == "true").getOrElse(true)
       val rootPathsSpecified = DataSource.checkAndGlobPathIfNecessary(paths, hadoopConf,
-        checkEmptyGlobPath = true, checkFilesExist = true)
+        checkEmptyGlobPath = true, checkFilesExist = true, enableGlobbing = globPaths)
       val fileStatusCache = FileStatusCache.getOrCreate(sparkSession)
       val fileIndex = new InMemoryFileIndex(
         sparkSession, rootPathsSpecified, caseSensitiveMap, userSpecifiedSchema, fileStatusCache)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Necessary changes to support Spark 3.1.2.
The following changes are needed:
1. `SQLTimestamp` is not used following [SPARK-30865](https://github.com/apache/spark/commit/17a5007fd8b9249593a703ba7659847ec09be2e8) and replace by `Long`
2. `DataSourceV2ScanRelation` constructor was changed to have `DataSourceV2Relation` instead of `Table` in the case class defintion in [SPARK-33652](https://github.com/apache/spark/commit/e857e06452c2cf478beb31367f76d6950b660ebb). Corresponding changes are made in the IndexBuilder and MetadataProcessor.
3. 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests