### PR TITLE
support indexing paths explicitly

### DIFF
--- a/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
+++ b/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
@@ -368,7 +368,7 @@ class IndexBuilder(spark: SparkSession, uri: String, xskipper: Xskipper)
 
     val partitionDirectories = filesToIndex match {
       case Some(files) =>
-        // first make sure the df is a catalog table
+        // if we were given a list of files to index, index only these files
         val leafDirToChildrenFiles = files.toArray.groupBy(_.getPath.getParent)
         val (rootPaths, parameters) = df.queryExecution.optimizedPlan match {
           case LogicalRelation(hfs: HadoopFsRelation, _, _, _) =>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/xskipper/DataSkippingUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/xskipper/DataSkippingUtils.scala
@@ -152,6 +152,11 @@ object DataSkippingUtils extends Logging {
     sparkSession.extensions.injectOptimizerRule(_ => rule)
   }
 
+  /**
+    * Given a sequence of qualified paths, tries to parse them and returns a
+    * partition specification.
+    * Using Spark's built-in private method to parse the partitions
+    */
   def parsePartitions(sparkSession: SparkSession, files: Seq[FileStatus],
                       schema: StructType, basePaths: Set[Path],
                       parameters: Map[String, String]): PartitionSpec = {

--- a/src/test/scala/io/xskipper/metadatastore/parquet/HiveMetastoreTestSuiteParquet.scala
+++ b/src/test/scala/io/xskipper/metadatastore/parquet/HiveMetastoreTestSuiteParquet.scala
@@ -406,7 +406,6 @@ abstract class HiveMetastoreTestSuiteParquet(override val datasourceV2: Boolean 
       val expectedSkippedFiles = Seq(
         "dt=2017-07-15/c1.snappy.parquet",
         "dt=2017-07-15/c0.snappy.parquet")
-      // include the main table location and the side partition
       var expectedSkippedFilesFormatted =
         Utils.getResultSet(input_path, expectedSkippedFiles: _*)
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds the ability to build/refresh an index by specifying the list of objects to be indexed or the partitions paths explicitly and thus avoid listing the entire dataset in order to index a new partition.
Currently this mode is supported only for catalog tables.

### Does this PR introduce _any_ user-facing change?

Yes, adding an API to index specific objects/partitions for hive tables to avoid listing the entire table

### How was this patch tested?

Adding tests