### PR TITLE
fix stats issue

### DIFF
--- a/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
+++ b/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
@@ -410,7 +410,10 @@ class IndexBuilder(spark: SparkSession, uri: String, xskipper: Xskipper)
       xskipper.metadataHandle().finalizeMetadataUpload()
     }
 
+    // calculate the number of files that were indexed
+    val numFilesIndexed = newOrModifiedFilesIDs.foldLeft(0)((x, y) => x + y.files.length)
+
     // return the operation values
-    Seq(RefreshResult(Status.SUCCESS, newOrModifiedFilesIDs.length, removedCount)).toDS().toDF()
+    Seq(RefreshResult(Status.SUCCESS, numFilesIndexed, removedCount)).toDS().toDF()
   }
 }

--- a/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
+++ b/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
@@ -150,6 +150,7 @@ abstract class XskipperAPISuiteBase(val mdStore: MetadataStoreManagerType,
             FileUtils.copyDirectory(updatedInputLoc, dir, false)
             val xskipper = getXskipper(dir)
             val buildRes = xskipper.refreshIndex(reader)
+            assert(Utils.isResDfValid(buildRes))
         }
       val newFilesToSkip = datasetLocators.zip(tempDirs).flatMap {
         case (descriptor: DatasetDescriptor, dir: String) =>

--- a/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
+++ b/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
@@ -122,13 +122,10 @@ abstract class XskipperAPISuiteBase(val mdStore: MetadataStoreManagerType,
         val origInputLoc = Utils.concatPaths(descriptor.inputLocation, format)
         logInfo(s"Copying $origInputLoc to $dir")
         FileUtils.copyDirectory(origInputLoc, dir, false)
-        // get the number of files in the tests
-        val numFilesToIndex = Some(FileUtils.listFiles(dir,
-          TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE).size())
         val xskipper = getXskipper(dir)
         assert(!xskipper.isIndexed())
         val buildRes = getIndexBuilder(xskipper, descriptor.indexTypes).build(reader)
-        assert(Utils.isResDfValid(buildRes, numFilesToIndex), numFilesToIndex)
+        assert(Utils.isResDfValid(buildRes))
         assert(xskipper.isIndexed())
     }
 
@@ -151,12 +148,8 @@ abstract class XskipperAPISuiteBase(val mdStore: MetadataStoreManagerType,
           case (descriptor: DatasetDescriptor, dir: String) =>
             val updatedInputLoc = Utils.concatPaths(descriptor.updatedInputLocation.get, format)
             FileUtils.copyDirectory(updatedInputLoc, dir, false)
-            // get the number of files in the tests
-            val numFilesToIndex = Some(FileUtils.listFiles(dir,
-              TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE).size())
             val xskipper = getXskipper(dir)
             val buildRes = xskipper.refreshIndex(reader)
-            assert(Utils.isResDfValid(buildRes, numFilesToIndex))
         }
       val newFilesToSkip = datasetLocators.zip(tempDirs).flatMap {
         case (descriptor: DatasetDescriptor, dir: String) =>

--- a/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
+++ b/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
@@ -13,7 +13,6 @@ import io.xskipper.testing.util.Utils._
 import io.xskipper.testing.util.{LogTrackerBuilder, Utils}
 import io.xskipper.{Xskipper, _}
 import org.apache.commons.io.FileUtils
-import org.apache.commons.io.filefilter.TrueFileFilter
 import org.apache.log4j.{Level, LogManager}
 import org.apache.spark.internal.Logging
 import org.scalatest.{BeforeAndAfterEach, FunSuite}

--- a/src/test/scala/io/xskipper/testing/util/Utils.scala
+++ b/src/test/scala/io/xskipper/testing/util/Utils.scala
@@ -85,9 +85,24 @@ object Utils {
   }
 
 
-  def isResDfValid(df: DataFrame): Boolean = {
+  def isResDfValid(df: DataFrame, expectedNumIndexedFiles: Option[Int] = None,
+                   expectedNumRemovedFiles: Option[Int] = None): Boolean = {
     val status = df.select("status").rdd.map(r => r(0)).collect()
-    return status.length == 1 && status.head.asInstanceOf[String] == "SUCCESS"
+    expectedNumIndexedFiles match {
+      case Some(n) =>
+        val numIndexedFiles = df.select("new_entries_added")
+          .rdd.map(r => r(0)).collect().head.asInstanceOf[Int]
+        assert(numIndexedFiles == n)
+      case _ =>
+    }
+    expectedNumRemovedFiles match {
+      case Some(n) =>
+        val numRemovedFiles = df.select("old_entries_removed")
+          .rdd.map(r => r(0)).collect().head.asInstanceOf[Int]
+        assert(numRemovedFiles == n)
+      case _ =>
+    }
+    status.length == 1 && status.head.asInstanceOf[String] == "SUCCESS"
   }
 
   def getIndexBuilder(xskipper: Xskipper, indexTypes: Seq[(String, Seq[String])]): IndexBuilder = {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Due to a bug the number of objects indexed reported by the dataframe returned from calling `build` on the index builder is wrong and represents only the number of partitions that were indexed.
This bug was introduced when xskipper started saving also the partition columns in the metadata (see #48 and #60).

### Does this PR introduce _any_ user-facing change?

Yes. 
The reported number of objects indexed/refreshed in the result dataframe of the index `build` / `refresh` operation is now correct.

### How was this patch tested?

This PR fixes this and also adds a test to verify the number of indexed and removed files is reported correctly both on indexing and refreshing.
Note that the tests were not added to the API tests since there is no reliable way to make sure a non empty dataset is being indexed without making much bigger change (empty files are not indexed by xskipper).
