### PR TITLE
Spark 3.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           architecture: x64
       - name: Install Python packages (Python 3.7)
         run: |
-          python3.7 -m pip install pyspark==3.2.0
+          python3.7 -m pip install pyspark==3.3.0
       - name: Run sbt clean
         run: build/sbt ++2.12.8 clean
       - name: Run sbt compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           architecture: x64
       - name: Install Python packages (Python 3.7)
         run: |
-          python3.7 -m pip install pyspark==3.2.0
+          python3.7 -m pip install pyspark==3.3.0
       - name: Run Python tests
         run: python3.7 run-tests.py
       - if: |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Xskipper is compatible with Spark according to the following table:
 
 | Xskipper version | Spark Version        |
 | --------------- | --------------------- |
+| 1.4.x           | 3.3.x   |
 | 1.3.x           | 3.2.x   |
 | 1.2.x           | 3.0.x   | 
 | 1.1.x           | 2.4.x   | 

--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ libraryDependencies ++= Seq (
   "org.apache.spark" %% "spark-hive" % sparkVersion.value % "test",
   "com.googlecode.json-simple" % "json-simple" % "1.1" % "test",
   // dependency for InMemoryKMS to test parquet encryption
-  "org.apache.parquet" % "parquet-hadoop" % "1.12.1" % "test",
-  "org.apache.parquet" % "parquet-hadoop" % "1.12.1" % "test" classifier "tests"
+  "org.apache.parquet" % "parquet-hadoop" % "1.12.3" % "test",
+  "org.apache.parquet" % "parquet-hadoop" % "1.12.3" % "test" classifier "tests"
 )
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq (
   "org.apache.spark" %% "spark-core" % sparkVersion.value % "test",
   "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test",
   "org.apache.spark" %% "spark-hive" % sparkVersion.value % "test",
-  "com.googlecode.json-simple" % "json-simple" % "1.1" % "test"
+  "com.googlecode.json-simple" % "json-simple" % "1.1" % "test",
   // dependency for InMemoryKMS to test parquet encryption
   "org.apache.parquet" % "parquet-hadoop" % "1.12.2" % "test",
   "org.apache.parquet" % "parquet-hadoop" % "1.12.2" % "test" classifier "tests"

--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,10 @@ libraryDependencies ++= Seq (
   "org.apache.spark" %% "spark-core" % sparkVersion.value % "test",
   "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test",
   "org.apache.spark" %% "spark-hive" % sparkVersion.value % "test",
-  "com.googlecode.json-simple" % "json-simple" % "1.1" % "test",
+  "com.googlecode.json-simple" % "json-simple" % "1.1" % "test"
   // dependency for InMemoryKMS to test parquet encryption
-  "org.apache.parquet" % "parquet-hadoop" % "1.12.3" % "test",
-  "org.apache.parquet" % "parquet-hadoop" % "1.12.3" % "test" classifier "tests"
+  "org.apache.parquet" % "parquet-hadoop" % "1.12.2" % "test",
+  "org.apache.parquet" % "parquet-hadoop" % "1.12.2" % "test" classifier "tests"
 )
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ crossScalaVersions := Seq("2.12.8")
 
 scalaVersion := crossScalaVersions.value.head
 
-sparkVersion := "3.2.0"
+sparkVersion := "3.3.0"
 
 libraryDependencies ++= Seq (
   "org.apache.spark" %% "spark-hive" % sparkVersion.value % "provided",

--- a/python/xskipper/indexbuilder.py
+++ b/python/xskipper/indexbuilder.py
@@ -89,7 +89,7 @@ class IndexBuilder:
         :return: dataFrame object containing statistics about the build operation
         """
         if reader:
-            return DataFrame(self._jindexBuilder.build(reader._jreader), self.spark._wrapped)
+            return DataFrame(self._jindexBuilder.build(reader._jreader), self.spark)
         else:
             # build for tables
-            return DataFrame(self._jindexBuilder.build(), self.spark._wrapped)
+            return DataFrame(self._jindexBuilder.build(), self.spark)

--- a/python/xskipper/xskipper.py
+++ b/python/xskipper/xskipper.py
@@ -47,10 +47,10 @@ class Xskipper:
         :raises XskipperException: if index cannot be refreshed
         """
         if dataFrameReader:
-            return DataFrame(self.xskipper.refreshIndex(dataFrameReader._jreader), self.spark._wrapped)
+            return DataFrame(self.xskipper.refreshIndex(dataFrameReader._jreader), self.spark)
         else:
             # refresh for tables
-            return DataFrame(self.xskipper.refreshIndex(), self.spark._wrapped)
+            return DataFrame(self.xskipper.refreshIndex(), self.spark)
 
     def isIndexed(self):
         """
@@ -78,9 +78,9 @@ class Xskipper:
         :raises XskipperException: if index cannot be refreshed
         """
         if dataFrameReader:
-            return DataFrame(self.xskipper.describeIndex(dataFrameReader._jreader), self.spark._wrapped)
+            return DataFrame(self.xskipper.describeIndex(dataFrameReader._jreader), self.spark)
         else:
-            return DataFrame(self.xskipper.describeIndex(), self.spark._wrapped)
+            return DataFrame(self.xskipper.describeIndex(), self.spark)
 
     def getLatestQueryStats(self):
         """
@@ -103,7 +103,7 @@ class Xskipper:
 
         :return: object containing information about latest query stats
         """
-        return DataFrame(self.xskipper.getLatestQueryStats(), self.spark._wrapped)
+        return DataFrame(self.xskipper.getLatestQueryStats(), self.spark)
 
     def setParams(self, params):
         """
@@ -196,7 +196,7 @@ class Xskipper:
         :return: dataFrame object containing information about latest query stats
         """
         return DataFrame(sparkSession._jvm.io.xskipper.Xskipper.getLatestQueryAggregatedStats(
-            sparkSession._jsparkSession), sparkSession._wrapped)
+            sparkSession._jsparkSession), sparkSession)
 
     @staticmethod
     def clearStats(sparkSession):
@@ -231,7 +231,7 @@ class Xskipper:
                  under the configured base path
         """
         return DataFrame(sparkSession._jvm.io.xskipper.Xskipper.listIndexes(sparkSession._jsparkSession),
-                         sparkSession._wrapped)
+                         sparkSession)
 
     @staticmethod
     def enable(sparkSession):

--- a/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
+++ b/src/main/scala/io/xskipper/index/execution/IndexBuilder.scala
@@ -325,7 +325,7 @@ class IndexBuilder(spark: SparkSession, uri: String, xskipper: Xskipper)
       case l@LogicalRelation(hfs: HadoopFsRelation, _, _, _) =>
         (hfs.fileFormat.toString, hfs.options, hfs.location)
       // scalastyle:off line.size.limit
-      case _@DataSourceV2ScanRelation(_@DataSourceV2Relation(table: FileTable, _, _, _, _), _, _) =>
+      case _@DataSourceV2ScanRelation(_@DataSourceV2Relation(table: FileTable, _, _, _, _), _, _, _) =>
         (table.formatName, table.properties().asScala.toMap, table.fileIndex)
       // scalastyle:on line.size.limit
     }(0)

--- a/src/main/scala/io/xskipper/index/execution/MetadataProcessor.scala
+++ b/src/main/scala/io/xskipper/index/execution/MetadataProcessor.scala
@@ -46,7 +46,7 @@ object MetadataProcessor {
       case l@LogicalRelation(hfs: HadoopFsRelation, _, _, _) =>
         hfs.location.listFiles(Seq.empty, Seq.empty)
       // scalastyle:off line.size.limit
-      case _@DataSourceV2ScanRelation(_@DataSourceV2Relation(table: FileTable, _, _, _, _), _, _) =>
+      case _@DataSourceV2ScanRelation(_@DataSourceV2Relation(table: FileTable, _, _, _, _), _, _, _) =>
         // not using allFiles since it returns also empty files which are not used
         // since Spark only calls list files during query processing
         table.fileIndex.listFiles(Seq.empty, Seq.empty)

--- a/src/main/scala/io/xskipper/search/filters/ValueListFilter.scala
+++ b/src/main/scala/io/xskipper/search/filters/ValueListFilter.scala
@@ -9,7 +9,7 @@ import io.xskipper.search.clause.{Clause, FalseClause, ValueListClause}
 import io.xskipper.search.expressions.MetadataWrappedExpression
 import io.xskipper.utils.Utils
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.types.{ArrayType, DataType}
+import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType}
 
 /**
   * Represents a value list filter in - used to add [[ValueListClause]]-s
@@ -45,6 +45,9 @@ case class ValueListFilter(col : String) extends BaseMetadataFilter {
         Some(Array(v.value), expr.dataType)
       case EqualTo(v: Literal, expr: Expression) if isValidExpr(expr) =>
         Some(Array(v.value), expr.dataType)
+      case AttributeReference(name, typ, _, _) if typ.isInstanceOf[BooleanType] &&
+        name.equalsIgnoreCase(col) =>
+        Some(Array(true), typ)
       case _ => None
     }
 

--- a/src/main/scala/io/xskipper/utils/Utils.scala
+++ b/src/main/scala/io/xskipper/utils/Utils.scala
@@ -176,9 +176,9 @@ object Utils extends Logging {
       */
     // Note using optimized plan to force resolving
     df.queryExecution.optimizedPlan match {
-      case LogicalRelation(hfs: HadoopFsRelation, _, _, _) =>
-        hfs.partitionSchemaOption
-      case DataSourceV2ScanRelation(_, scan: FileScan, _) =>
+      case LogicalRelation(hfs: HadoopFsRelation, _, _, _) if hfs.partitionSchema.nonEmpty =>
+        Some(hfs.partitionSchema)
+      case DataSourceV2ScanRelation(_, scan: FileScan, _, _) =>
         Some(scan.fileIndex.partitionSchema)
       case _ => None
     }

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -38,21 +38,29 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-test.appender=file
-log4j.rootCategory=INFO, ${test.appender}
-log4j.appender.file=org.apache.log4j.FileAppender
-log4j.appender.file.append=true
-log4j.appender.file.file=target/unit-tests.log
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+rootLogger.level = info
+rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
+
+appender.file.type = File
+appender.file.name = File
+appender.file.fileName = target/unit-tests.log
+appender.file.append = true
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
 # Tests that launch java subprocesses can set the "test.appender" system property to
 # "console" to avoid having the child process's logs overwrite the unit test's
 # log file.
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%t: %m%n
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
 # Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.spark_project.jetty=WARN
+logger.jetty.name = org.sparkproject.jetty
+logger.jetty.level = warn
+
+# xskipper set to debug
+logger.xskipper.name = io.xskipper.search
+logger.xskipper.level = debug

--- a/src/test/scala/io/xskipper/api/IllegalSchemaSuiteBase.scala
+++ b/src/test/scala/io/xskipper/api/IllegalSchemaSuiteBase.scala
@@ -66,7 +66,8 @@ abstract class IllegalSchemaSuiteBase(override val datasourceV2: Boolean = false
     FileUtils.copyDirectory(new File(badInputPath), destInputFile)
     // make sure invalid schema warning is logged
     val invalidSchemeRegex = "Schema is invalid for file:(.*), no skipping will be attempted".r
-    val invalidSchemaTracker = LogTrackerBuilder.getRegexTracker("skipped", invalidSchemeRegex)
+    val invalidSchemaTracker = LogTrackerBuilder.getRegexTracker("invalidSchemeRegex",
+      invalidSchemeRegex)
     val df2 = spark.read.parquet(destInputPath)
     df2.createOrReplaceTempView("foo2")
     skippedFilesTracker.clearSet()

--- a/src/test/scala/io/xskipper/api/IllegalSchemaSuiteBase.scala
+++ b/src/test/scala/io/xskipper/api/IllegalSchemaSuiteBase.scala
@@ -31,7 +31,7 @@ abstract class IllegalSchemaSuiteBase(override val datasourceV2: Boolean = false
     "src/test/resources/input_datasets/schema_validation/bad_input/")
 
   test("Test illegal schema through evolution") {
-    val skippedFilesTracker = LogTrackerBuilder.getRegexTracker(regexp)
+    val skippedFilesTracker = LogTrackerBuilder.getRegexTracker("skipped", regexp)
     val destDir = Files.createTempDirectory("xskipper_schema_validation").toString
     destDir.deleteOnExit()
     val destFile = new File(destDir)
@@ -66,7 +66,7 @@ abstract class IllegalSchemaSuiteBase(override val datasourceV2: Boolean = false
     FileUtils.copyDirectory(new File(badInputPath), destInputFile)
     // make sure invalid schema warning is logged
     val invalidSchemeRegex = "Schema is invalid for file:(.*), no skipping will be attempted".r
-    val invalidSchemaTracker = LogTrackerBuilder.getRegexTracker(invalidSchemeRegex)
+    val invalidSchemaTracker = LogTrackerBuilder.getRegexTracker("skipped", invalidSchemeRegex)
     val df2 = spark.read.parquet(destInputPath)
     df2.createOrReplaceTempView("foo2")
     skippedFilesTracker.clearSet()

--- a/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
+++ b/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
@@ -67,7 +67,7 @@ abstract class XskipperAPISuiteBase(val mdStore: MetadataStoreManagerType,
                   tempDirs: Seq[String],
                   format: String,
                   query: String): Unit = {
-    val tracker = LogTrackerBuilder.getRegexTracker(regexp)
+    val tracker = LogTrackerBuilder.getRegexTracker("skipped", regexp)
 
     val reader = Utils.getDefaultReader(spark, format)
     val suffix = Utils.getDefaultSuffix(format)

--- a/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
+++ b/src/test/scala/io/xskipper/api/XskipperAPISuiteBase.scala
@@ -13,7 +13,9 @@ import io.xskipper.testing.util.Utils._
 import io.xskipper.testing.util.{LogTrackerBuilder, Utils}
 import io.xskipper.{Xskipper, _}
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.config.{Configurator, LoggerConfig}
+import org.apache.logging.log4j.{Level, LogManager}
 import org.apache.spark.internal.Logging
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
@@ -26,9 +28,6 @@ abstract class XskipperAPISuiteBase(val mdStore: MetadataStoreManagerType,
     with BeforeAndAfterEach
     with XskipperProvider
     with Logging {
-
-  // set debug log level specifically for xskipper search package
-  LogManager.getLogger("io.xskipper.search").setLevel(Level.DEBUG)
 
   // monitor skipped files
   val regexp = "(.*).*#.*--------> SKIPPED!".r

--- a/src/test/scala/io/xskipper/metadatastore/parquet/HiveMetastoreTestSuiteParquet.scala
+++ b/src/test/scala/io/xskipper/metadatastore/parquet/HiveMetastoreTestSuiteParquet.scala
@@ -61,7 +61,7 @@ abstract class HiveMetastoreTestSuiteParquet(override val datasourceV2: Boolean 
 
   // monitor skipped files
   val regexp = "(.*).*#.*--------> SKIPPED!".r
-  val skippedFiles = LogTrackerBuilder.getRegexTracker(regexp)
+  val skippedFiles = LogTrackerBuilder.getRegexTracker("skipped", regexp)
 
   val baseDir = Utils.concatPaths(System.getProperty("user.dir"), "src/test/resources")
 

--- a/src/test/scala/io/xskipper/metadatastore/parquet/HiveMetastoreTestSuiteParquet.scala
+++ b/src/test/scala/io/xskipper/metadatastore/parquet/HiveMetastoreTestSuiteParquet.scala
@@ -21,9 +21,6 @@ import org.scalatest.{BeforeAndAfterEach, FunSuite}
   * Test suite to check data skipping integration with hive metastore
   * Note: tests that check for skipping files need the logging for
   * io.xskipper.search to be on DEBUG level
-  * This can also be set by having log4j.properties
-  * in the resources folder and setting there:
-  * log4j.logger.io.xskipper.search=DEBUG
   */
 
 abstract class HiveMetastoreTestSuiteParquet(override val datasourceV2: Boolean = false)
@@ -73,9 +70,6 @@ abstract class HiveMetastoreTestSuiteParquet(override val datasourceV2: Boolean 
   val fullTableName = s"$databaseName.$tableName"
   val viewName = s"${tableName}_view"
   val fullViewName = s"$databaseName.$viewName"
-  // set debug log level specifically for xskipper package
-  LogManager.getLogger("io.xskipper").setLevel(Level.DEBUG)
-
 
   def testHiveTable(useLegacyLocationInDatabase: Boolean,
                     useLegacyLocationInTable: Boolean): Unit = {

--- a/src/test/scala/io/xskipper/metadatastore/parquet/types/PartitionTypeSupportParquet.scala
+++ b/src/test/scala/io/xskipper/metadatastore/parquet/types/PartitionTypeSupportParquet.scala
@@ -28,11 +28,11 @@ abstract class PartitionTypeSupportParquet(override val datasourceV2: Boolean)
 
   LogManager.getLogger("io.xskipper.search.DataSkippingFileFilter").setLevel(Level.DEBUG)
   val skippedRegexp = "(.*).*#.*--------> SKIPPED!".r
-  val skippedFiles = LogTrackerBuilder.getRegexTracker(skippedRegexp)
+  val skippedFiles = LogTrackerBuilder.getRegexTracker("skipped", skippedRegexp)
   val requiredRegexp = "(.*).*#.*--------> REQUIRED!".r
-  val requiredFiles = LogTrackerBuilder.getRegexTracker(requiredRegexp)
+  val requiredFiles = LogTrackerBuilder.getRegexTracker("required", requiredRegexp)
   val indexedRegexp = "(.*).*#.*--------> INDEXED!".r
-  val indexedFiles = LogTrackerBuilder.getRegexTracker(indexedRegexp)
+  val indexedFiles = LogTrackerBuilder.getRegexTracker("indexed", indexedRegexp)
 
 
   def resetTrackers(): Unit = {

--- a/src/test/scala/io/xskipper/metadatastore/parquet/versioning/VersionTestSuite.scala
+++ b/src/test/scala/io/xskipper/metadatastore/parquet/versioning/VersionTestSuite.scala
@@ -92,7 +92,7 @@ class VersionTestSuite(override val datasourceV2: Boolean) extends FunSuite
       // (the timestamp is different) so we check using the SKIPPABLE regex
       // as the files won't be skipped.
       val skippableFilesTracker: LogTracker[String] =
-      LogTrackerBuilder.getRegexTracker(skippableFilesRegex)
+      LogTrackerBuilder.getRegexTracker("skippable", skippableFilesRegex)
       skippableFilesTracker.startCollecting()
       // read the input dataset & run the queries
       val df = testDescriptor.getDFReader(spark).load(testDescriptor.getFullDestPath())
@@ -121,7 +121,7 @@ class VersionTestSuite(override val datasourceV2: Boolean) extends FunSuite
       // we've just refreshed the md - it should actually contain
       // an entry for our files, we should expect to see them skipped!
       val skippedFilesTracker: LogTracker[String] =
-      LogTrackerBuilder.getRegexTracker(skippedFilesRegex)
+      LogTrackerBuilder.getRegexTracker("skipped", skippedFilesRegex)
       skippedFilesTracker.startCollecting()
       // read the input dataset & run the queries
       val df = reader.load(testDescriptor.getFullDestPath())

--- a/src/test/scala/io/xskipper/testing/util/LogTracker.scala
+++ b/src/test/scala/io/xskipper/testing/util/LogTracker.scala
@@ -51,6 +51,7 @@ class LogTracker[T](
     if (!started) {
       started = true
       rootLogger.addAppender(this, null, null)
+      this.start()
     }
   }
 
@@ -59,6 +60,7 @@ class LogTracker[T](
     if (started) {
       started = false
       rootLogger.removeAppender(name)
+      this.stop()
     }
   }
 

--- a/src/test/scala/io/xskipper/testing/util/LogTrackerBuilder.scala
+++ b/src/test/scala/io/xskipper/testing/util/LogTrackerBuilder.scala
@@ -26,14 +26,6 @@ object LogTrackerBuilder {
       }
     }
 
-    val filter = (event: LogEvent) => {
-      val msg = event.getMessage().toString
-      msg match {
-        case regex(_) => true
-        case _ => false
-      }
-    }
-
     new LogTracker[String](name, regex, action)
   }
 }

--- a/src/test/scala/io/xskipper/testing/util/LogTrackerBuilder.scala
+++ b/src/test/scala/io/xskipper/testing/util/LogTrackerBuilder.scala
@@ -16,7 +16,7 @@ import scala.util.matching.Regex
 object LogTrackerBuilder {
 
   // creates a log tracker that tracks the skipped files
-  def getRegexTracker(regex: Regex): LogTracker[String] = {
+  def getRegexTracker(name: String, regex: Regex): LogTracker[String] = {
 
     val action = (event: LogEvent) => {
       val msg = event.getMessage().toString
@@ -34,6 +34,6 @@ object LogTrackerBuilder {
       }
     }
 
-    new LogTracker[String]("xskipper", regex, action)
+    new LogTracker[String](name, regex, action)
   }
 }

--- a/src/test/scala/io/xskipper/testing/util/LogTrackerBuilder.scala
+++ b/src/test/scala/io/xskipper/testing/util/LogTrackerBuilder.scala
@@ -5,7 +5,7 @@
 
 package io.xskipper.testing.util
 
-import org.apache.log4j.spi.LoggingEvent
+import org.apache.logging.log4j.core.LogEvent
 
 import scala.util.matching.Regex
 
@@ -18,7 +18,7 @@ object LogTrackerBuilder {
   // creates a log tracker that tracks the skipped files
   def getRegexTracker(regex: Regex): LogTracker[String] = {
 
-    val action = (event: LoggingEvent) => {
+    val action = (event: LogEvent) => {
       val msg = event.getMessage().toString
       msg match {
         case regex(value) => value
@@ -26,14 +26,14 @@ object LogTrackerBuilder {
       }
     }
 
-    val filter = (event: LoggingEvent) => {
+    val filter = (event: LogEvent) => {
       val msg = event.getMessage().toString
       msg match {
-        case regex(value) => true
+        case regex(_) => true
         case _ => false
       }
     }
 
-    new LogTracker[String](regex, filter, action)
+    new LogTracker[String]("xskipper", regex, action)
   }
 }

--- a/src/test/scala/io/xskipper/types/TypeSupportUtils.scala
+++ b/src/test/scala/io/xskipper/types/TypeSupportUtils.scala
@@ -17,7 +17,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 object TypeSupportUtils extends Logging {
   // monitor skipped files
   val regexp = "(.*).*#.*--------> SKIPPED!".r
-  val skippedFiles = LogTrackerBuilder.getRegexTracker(regexp)
+  val skippedFiles = LogTrackerBuilder.getRegexTracker("skipped", regexp)
 
   /**
     * Checks skipping for a given dataframe by calling show and the dataframe

--- a/src/test/scala/io/xskipper/types/ValueListIndexTypeSupportBase.scala
+++ b/src/test/scala/io/xskipper/types/ValueListIndexTypeSupportBase.scala
@@ -22,7 +22,7 @@ abstract class ValueListIndexTypeSupportBase(override val datasourceV2: Boolean)
 
   // monitor skipped files
   val regexp = "(.*).*#.*--------> SKIPPED!".r
-  val skippedFiles = LogTrackerBuilder.getRegexTracker(regexp)
+  val skippedFiles = LogTrackerBuilder.getRegexTracker("skipped", regexp)
 
   val userDir = System.getProperty("user.dir")
   val inputPath = Utils.concatPaths(userDir,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.1-SNAPSHOT"
+version in ThisBuild := "1.4.0-SNAPSHOT"


### PR DESCRIPTION
### What changes are proposed in this pull request?

Spark 3.3 support.
Contains the following changes:
- Change testing to use log4j2 
- Change Python API to use the update DataFrame constructor
- Enhance ValueListFilter to support boolean pushdown following SPARK-36721
- Fixes needed to use the new DataSourceV2ScanRelation constructor

Note that the KeyGroupedPartitioning that was added is for the read path

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests